### PR TITLE
partitionmanager: handle dynamic partitions in a different way

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -150,6 +150,20 @@ ifneq ($(wildcard system/core/libsparse/Android.mk),)
 LOCAL_SHARED_LIBRARIES += libsparse
 endif
 
+# Logical Partition hacks
+ifeq ($(IGNORE_UPDATE_LOGICAL_PARTITION_ERROR),true)
+    LOCAL_CFLAGS += -DIGNORE_UPDATE_LOGICAL_PARTITION_ERROR=1
+endif
+
+ifeq ($(ALLOW_LOGICAL_PARTITION_WIPE),true)
+    LOCAL_CFLAGS += -DALLOW_LOGICAL_PARTITION_WIPE=1
+endif
+
+ifneq ($(BOARD_RW_DYNAMIC_PARTITIONS_LIST),)
+	LOCAL_CFLAGS += "-DBOARD_RW_DYNAMIC_PARTITIONS_LIST=\"$(shell echo $(BOARD_RW_DYNAMIC_PARTITIONS_LIST) | sed -r 's/\b(.)/\1/g' | sed -e 's/ \+/,/g')\""
+endif
+# end lp hacks
+
 ifeq ($(TW_OEM_BUILD),true)
     LOCAL_CFLAGS += -DTW_OEM_BUILD
     BOARD_HAS_NO_REAL_SDCARD := true


### PR DESCRIPTION
this will enable devs to treat dynamic partition as normal partitions, allows direct flashing to logical partitions and allows to mount them as RW natively.
firstly, all the flags in BoardConfig.mk should be disabled (see commit: soulr344/android_device_samsung_m21nsxx@42b5629)
secondly, remove dynamic mounting system mounting from fstab and add normal mounts for them (see commit: soulr344/android_device_samsung_m21nsxx@b51bb0f)
lastly, remove any dynamic partition traces (system.prop) and add flags as your needs from soulr344/android_device_samsung_m21nsxx@56d9ef8 (remove comments)

Tested only on samgung super devices, should work on other manufacturers as well.

Signed-off-by: soulr344 <soul@totsuka.gq>