### PR TITLE
events: fix haptics on newer Samsung devices

### DIFF
--- a/minuitwrp/Android.mk
+++ b/minuitwrp/Android.mk
@@ -17,6 +17,10 @@ ifeq ($(TW_SUPPORT_INPUT_1_2_HAPTICS),true)
     endif
 endif
 
+ifeq ($(TW_USE_SAMSUNG_HAPTICS),true)
+    LOCAL_CFLAGS += -DTW_USE_SAMSUNG_HAPTICS=1
+endif
+
 ifneq ($(TW_BOARD_CUSTOM_GRAPHICS),)
     $(warning ****************************************************************************)
     $(warning * TW_BOARD_CUSTOM_GRAPHICS support has been deprecated in TWRP.            *)

--- a/minuitwrp/events.cpp
+++ b/minuitwrp/events.cpp
@@ -140,6 +140,13 @@ int vibrate(int timeout_ms)
     if (vib != nullptr) {
         vib->on((uint32_t)timeout_ms);
     }
+#elif TW_USE_SAMSUNG_HAPTICS
+    /* Newer Samsung devices have duration file only
+     0 in VIBRATOR_TIMEOUT_FILE means no vibration
+     Anything else is the vibration running for X milliseconds */
+    if (std::ifstream(VIBRATOR_TIMEOUT_FILE).good()) {
+        write_to_file(VIBRATOR_TIMEOUT_FILE, tout);
+    }
 #else
     if (std::ifstream(LEDS_HAPTICS_ACTIVATE_FILE).good()) {
         write_to_file(LEDS_HAPTICS_DURATION_FILE, tout);


### PR DESCRIPTION
Newer Samsung devices have a single file that enables/disables/sets the timeout for vibration in /sys/class/timed_output/vibrator/enable
The content of the file determines the state of the vibrator, 0 being vibrator being off and any other value being the time in ms that the vibrator is going to run before resetting to 0 again.

Signed-off-by: soulr344 <soul@totsuka.gq>
Change-Id: I1144e139285494e43b8656229ad6df10d5b48f39
Signed-off-by: soulr344 <soul@totsuka.gq>